### PR TITLE
Make repo management optional

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -61,6 +61,7 @@ The following parameters are available in the `bolt` class:
 * [`gpgkey`](#-bolt--gpgkey)
 * [`use_release_package`](#-bolt--use_release_package)
 * [`yumrepo_base_url`](#-bolt--yumrepo_base_url)
+* [`manage_repo`](#-bolt--manage_repo)
 
 ##### <a name="-bolt--version"></a>`version`
 
@@ -109,6 +110,14 @@ Data type: `Stdlib::HTTPSUrl`
 configure the full repo URL, useful when you don't exactly mirror yum.puppet.com
 
 Default value: `"${base_url}puppet-tools/el/${facts['os']['release']['major']}/\$basearch"`
+
+##### <a name="-bolt--manage_repo"></a>`manage_repo`
+
+Data type: `Boolean`
+
+when true, a repo will be added to install bolt. Useful when you manage repos externally. See also $use_release_package
+
+Default value: `true`
 
 ## Defined types
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -37,6 +37,15 @@ describe 'bolt' do
         it { is_expected.not_to contain_package('puppet-tools-release') }
         it { is_expected.to contain_yumrepo('puppet-tools').with_baseurl(%r{^https://bar.com}).with_gpgkey('https://foo.com/RPM-GPG-KEY-puppet-20250406') }
       end
+
+      context 'with manage_repo=false' do
+        let :params do
+          { manage_repo: false }
+        end
+
+        it { is_expected.not_to contain_package('puppet-tools-release') }
+        it { is_expected.not_to contain_yumrepo('puppet-tools') }
+      end
     end
   end
 end


### PR DESCRIPTION
this introduced a `manage_repo` parameter. By default we will install the puppet-tools release rpm or configure the yumrepo. When `manage_repo` is false, we won't do any of that and assume that the user has a repo that provides puppet-bolt. Useful for Satellite/Katello users or when you want to use distro repos.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
