### PR TITLE
bolt project: Include PE module path

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -204,5 +204,5 @@ Data type: `Array[Stdlib::Absolutepath]`
 
 an array of directories where code lives
 
-Default value: `["/etc/puppetlabs/code/environments/${environment}/modules", "/etc/puppetlabs/code/environments/${environment}/site",]`
+Default value: `["/etc/puppetlabs/code/environments/${environment}/modules", "/etc/puppetlabs/code/environments/${environment}/site", '/opt/puppetlabs/puppet/modules']`
 

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -26,7 +26,7 @@ define bolt::project (
   String[1] $group = $project,
   Boolean $manage_user = true,
   String[1] $environment = 'peadm',
-  Array[Stdlib::Absolutepath] $modulepaths = ["/etc/puppetlabs/code/environments/${environment}/modules", "/etc/puppetlabs/code/environments/${environment}/site",],
+  Array[Stdlib::Absolutepath] $modulepaths = ["/etc/puppetlabs/code/environments/${environment}/modules", "/etc/puppetlabs/code/environments/${environment}/site", '/opt/puppetlabs/puppet/modules'],
 ) {
   unless $facts['pe_status_check_role'] in ['primary', 'legacy_primary', 'pe_compiler', 'legacy_compiler'] {
     fail("bolt::project works only on PE primaries and compilers, not: ${facts['pe_status_check_role']}")


### PR DESCRIPTION
For some plans, for example working with PEADM, it's required to access to PE related modules as well.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
