### PR TITLE
Update Perforce gpg keys

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -93,7 +93,7 @@ Data type: `String[1]`
 
 name of the GPG key filename in the repo
 
-Default value: `$facts['os']['family'] ? { 'Debian' => 'DEB-GPG-KEY-puppet-20250406', 'RedHat' => 'RPM-GPG-KEY-puppet-20250406'`
+Default value: `$facts['os']['family'] ? { 'Debian' => 'DEB-GPG-KEY-future', 'RedHat' => 'RPM-GPG-KEY-puppet'`
 
 ##### <a name="-bolt--use_release_package"></a>`use_release_package`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@ class bolt (
   String[1] $version = 'installed',
   Stdlib::HTTPSUrl $base_url = $facts['os']['family'] ? { 'Debian' => 'https://apt.puppet.com/', 'RedHat' => 'https://yum.puppet.com/', },
   String[1] $release_package = $facts['os']['family'] ? { 'Debian' => "puppet-release-${fact('os.distro.codename')}.deb", 'RedHat' => "puppet-tools-release-el-${facts['os']['release']['major']}.noarch.rpm", },
-  String[1] $gpgkey = $facts['os']['family'] ? { 'Debian' => 'DEB-GPG-KEY-puppet-20250406', 'RedHat' => 'RPM-GPG-KEY-puppet-20250406', },
+  String[1] $gpgkey = $facts['os']['family'] ? { 'Debian' => 'DEB-GPG-KEY-future', 'RedHat' => 'RPM-GPG-KEY-puppet', },
   Boolean $use_release_package = $facts['os']['family'] ? { 'Debian' => false, 'RedHat' => true, },
   Stdlib::HTTPSUrl $yumrepo_base_url = "${base_url}puppet-tools/el/${facts['os']['release']['major']}/\$basearch",
   Boolean $manage_repo = true,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -47,7 +47,7 @@ describe 'bolt' do
         end
 
         it { is_expected.not_to contain_package('puppet-tools-release') }
-        it { is_expected.to contain_yumrepo('puppet-tools').with_baseurl(%r{^https://bar.com}).with_gpgkey('https://foo.com/RPM-GPG-KEY-puppet-20250406') }
+        it { is_expected.to contain_yumrepo('puppet-tools').with_baseurl(%r{^https://bar.com}).with_gpgkey('https://foo.com/RPM-GPG-KEY-puppet') }
       end
 
       context 'with manage_repo=false' do


### PR DESCRIPTION
The old keys expired. The "new" keys are the same as the old ones, just with an removed expire date.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
