### PR TITLE
Use versioned paths before legacy paths

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -206,7 +206,17 @@ Data type: `Array[Stdlib::Absolutepath]`
 
 an array of directories where code lives
 
-Default value: `["/etc/puppetlabs/code/environments/${environment}/modules", "/etc/puppetlabs/code/environments/${environment}/site", "/etc/puppetlabs/puppetserver/code/environments/${environment}/site/", "/etc/puppetlabs/puppetserver/code/environments/${environment}/modules/", '/opt/puppetlabs/puppet/modules']`
+Default value:
+
+```puppet
+[
+    "/etc/puppetlabs/code/environments/${environment}/modules",
+    "/etc/puppetlabs/code/environments/${environment}/site",
+    "/etc/puppetlabs/puppetserver/code/environments/${environment}/site/",
+    "/etc/puppetlabs/puppetserver/code/environments/${environment}/modules/",
+    '/opt/puppetlabs/puppet/modules',
+  ]
+```
 
 ##### <a name="-bolt--project--local_transport_tmpdir"></a>`local_transport_tmpdir`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -210,10 +210,10 @@ Default value:
 
 ```puppet
 [
-    "/etc/puppetlabs/code/environments/${environment}/modules",
-    "/etc/puppetlabs/code/environments/${environment}/site",
     "/etc/puppetlabs/puppetserver/code/environments/${environment}/site/",
     "/etc/puppetlabs/puppetserver/code/environments/${environment}/modules/",
+    "/etc/puppetlabs/code/environments/${environment}/modules",
+    "/etc/puppetlabs/code/environments/${environment}/site",
     '/opt/puppetlabs/puppet/modules',
   ]
 ```

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -29,10 +29,10 @@ define bolt::project (
   Boolean $manage_user = true,
   String[1] $environment = 'peadm',
   Array[Stdlib::Absolutepath] $modulepaths = [
-    "/etc/puppetlabs/code/environments/${environment}/modules",
-    "/etc/puppetlabs/code/environments/${environment}/site",
     "/etc/puppetlabs/puppetserver/code/environments/${environment}/site/",
     "/etc/puppetlabs/puppetserver/code/environments/${environment}/modules/",
+    "/etc/puppetlabs/code/environments/${environment}/modules",
+    "/etc/puppetlabs/code/environments/${environment}/site",
     '/opt/puppetlabs/puppet/modules',
   ],
   Optional[Stdlib::Absolutepath] $local_transport_tmpdir = undef,

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -28,7 +28,13 @@ define bolt::project (
   String[1] $group = $project,
   Boolean $manage_user = true,
   String[1] $environment = 'peadm',
-  Array[Stdlib::Absolutepath] $modulepaths = ["/etc/puppetlabs/code/environments/${environment}/modules", "/etc/puppetlabs/code/environments/${environment}/site", "/etc/puppetlabs/puppetserver/code/environments/${environment}/site/", "/etc/puppetlabs/puppetserver/code/environments/${environment}/modules/", '/opt/puppetlabs/puppet/modules'],
+  Array[Stdlib::Absolutepath] $modulepaths = [
+    "/etc/puppetlabs/code/environments/${environment}/modules",
+    "/etc/puppetlabs/code/environments/${environment}/site",
+    "/etc/puppetlabs/puppetserver/code/environments/${environment}/site/",
+    "/etc/puppetlabs/puppetserver/code/environments/${environment}/modules/",
+    '/opt/puppetlabs/puppet/modules',
+  ],
   Optional[Stdlib::Absolutepath] $local_transport_tmpdir = undef,
   Array[Stdlib::HTTPUrl] $puppetdb_urls = ['http://127.0.0.1:8080'],
 ) {


### PR DESCRIPTION
in the modulepath, the first match wins. When switching to versioned/lockless deploys, environments are copied from /etc/puppetlabs/code/environments to /etc/puppetlabs/puppetserver/code/. Future code deploys will write to  /etc/puppetlabs/puppetserver/code/, but the environments still exist in /etc/puppetlabs/code/environments. To make sure that we use the new versions, we need to check the new paths first.