### PR TITLE
Remove PE/primary constraint

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,6 @@
 fixtures:
   repositories:
     apt: https://github.com/puppetlabs/puppetlabs-apt.git
-    pe_status_check: https://github.com/puppetlabs/puppetlabs-pe_status_check.git
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
     sudo: https://github.com/saz/puppet-sudo.git
     systemd: https://github.com/voxpupuli/puppet-systemd.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,3 @@ jobs:
       beaker_staging_url: ${{ inputs.beaker_staging_url }}
       beaker_collection: ${{ inputs.beaker_collection }}
       beaker_staging_version: ${{ inputs.beaker_staging_version }}
-      beaker_facter: 'pe_status_check_role:PE-Role:primary'

--- a/.sync.yml
+++ b/.sync.yml
@@ -6,7 +6,5 @@ spec/spec_helper_acceptance.rb:
     - parameter_documentation
     - parameter_types
 .github/workflows/ci.yml:
-  with:
-    beaker_facter: 'pe_status_check_role:PE-Role:primary'
 spec/spec_helper.rb:
   facterdb_string_keys: true

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -38,12 +38,6 @@ define bolt::project (
   Optional[Stdlib::Absolutepath] $local_transport_tmpdir = undef,
   Array[Stdlib::HTTPUrl] $puppetdb_urls = ['http://127.0.0.1:8080'],
 ) {
-  unless $facts['pe_status_check_role'] {
-    fail('pe_status_check_role fact is missing from module puppetlabs/pe_status_check')
-  }
-  unless $facts['pe_status_check_role'] in ['primary', 'legacy_primary', 'pe_compiler', 'legacy_compiler'] {
-    fail("bolt::project works only on PE primaries and compilers, not: ${facts['pe_status_check_role']}")
-  }
   # installs bolt
   require bolt
 

--- a/metadata.json
+++ b/metadata.json
@@ -13,10 +13,6 @@
       "version_requirement": ">= 9.6.0 < 10.0.0"
     },
     {
-      "name": "puppetlabs/pe_status_check",
-      "version_requirement": ">= 4.2.0 < 5.0.0"
-    },
-    {
       "name": "puppet/systemd",
       "version_requirement": ">= 7.0.0 < 10.0.0"
     },

--- a/spec/defines/project_spec.rb
+++ b/spec/defines/project_spec.rb
@@ -7,65 +7,55 @@ describe 'bolt::project' do
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      context 'on FOSS' do
-        let :facts do
-          os_facts
-        end
-
-        it { is_expected.to compile.and_raise_error(%r{pe_status_check_role fact is missing from module puppetlabs/pe_status_check}) }
+      let :facts do
+        os_facts.merge({ sudoversion: '1.9.5p2' })
       end
 
-      context 'on PE' do
-        let :facts do
-          os_facts.merge({ pe_status_check_role: 'primary', sudoversion: '1.9.5p2' })
+      context 'with defaults' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('bolt') }
+        it { is_expected.to contain_file('/opt/peadm/bolt-project.yaml').with_ensure('file').with_content(%r{http://127.0.0.1:8080}) }
+        it { is_expected.to contain_file('/opt/peadm/inventory.yaml').with_ensure('file').without_content(%r{tmpdir}) }
+        it { is_expected.to contain_file('/opt/peadm').with_ensure('directory') }
+        it { is_expected.to contain_user(title) }
+        it { is_expected.to contain_group(title) }
+        it { is_expected.to contain_package('puppet-bolt') }
+        it { is_expected.not_to contain_yumrepo('puppet-tools') }
+        it { is_expected.to contain_sudo__conf(title) }
+        it { is_expected.to contain_systemd__unit_file("#{title}@.service") }
+
+        if os_facts['os']['family'] == 'RedHat'
+          it { is_expected.to contain_package('puppet-tools-release') }
+          it { is_expected.not_to contain_apt__source('puppet-tools-release') }
+        else
+          it { is_expected.not_to contain_package('puppet-tools-release') }
+          it { is_expected.to contain_apt__source('puppet-tools-release') }
+        end
+      end
+
+      context 'with https PuppetDB URL' do
+        let :params do
+          { puppetdb_urls: ['https://[::1]:8081'] }
         end
 
-        context 'with defaults' do
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_class('bolt') }
-          it { is_expected.to contain_file('/opt/peadm/bolt-project.yaml').with_ensure('file').with_content(%r{http://127.0.0.1:8080}) }
-          it { is_expected.to contain_file('/opt/peadm/inventory.yaml').with_ensure('file').without_content(%r{tmpdir}) }
-          it { is_expected.to contain_file('/opt/peadm').with_ensure('directory') }
-          it { is_expected.to contain_user(title) }
-          it { is_expected.to contain_group(title) }
-          it { is_expected.to contain_package('puppet-bolt') }
-          it { is_expected.not_to contain_yumrepo('puppet-tools') }
-          it { is_expected.to contain_sudo__conf(title) }
-          it { is_expected.to contain_systemd__unit_file("#{title}@.service") }
+        it { is_expected.to contain_file('/opt/peadm/bolt-project.yaml').with_ensure('file').with_content(%r{https://\[::1\]:8081}) }
+      end
 
-          if os_facts['os']['family'] == 'RedHat'
-            it { is_expected.to contain_package('puppet-tools-release') }
-            it { is_expected.not_to contain_apt__source('puppet-tools-release') }
-          else
-            it { is_expected.not_to contain_package('puppet-tools-release') }
-            it { is_expected.to contain_apt__source('puppet-tools-release') }
-          end
+      context 'with manage_user=false' do
+        let :params do
+          { manage_user: false }
         end
 
-        context 'with https PuppetDB URL' do
-          let :params do
-            { puppetdb_urls: ['https://[::1]:8081'] }
-          end
+        it { is_expected.not_to contain_user(title) }
+        it { is_expected.not_to contain_group(title) }
+      end
 
-          it { is_expected.to contain_file('/opt/peadm/bolt-project.yaml').with_ensure('file').with_content(%r{https://\[::1\]:8081}) }
+      context 'with local_transport_tmpdir' do
+        let :params do
+          { local_transport_tmpdir: '/foooo' }
         end
 
-        context 'with manage_user=false on PE' do
-          let :params do
-            { manage_user: false }
-          end
-
-          it { is_expected.not_to contain_user(title) }
-          it { is_expected.not_to contain_group(title) }
-        end
-
-        context 'with local_transport_tmpdir' do
-          let :params do
-            { local_transport_tmpdir: '/foooo' }
-          end
-
-          it { is_expected.to contain_file('/opt/peadm/inventory.yaml').with_ensure('file').with_content(%r{tmpdir: "/foooo"}) }
-        end
+        it { is_expected.to contain_file('/opt/peadm/inventory.yaml').with_ensure('file').with_content(%r{tmpdir: "/foooo"}) }
       end
     end
   end


### PR DESCRIPTION
Previously we used a fact from puppetlabs/pe_status_checks to limit the module to primaries. This doesn't make sense. First, it works on compilers as well. Second, the fact isn't very reliable, it doesn't work in `apply()` blocks in bolt plans, so lets just remove it.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
